### PR TITLE
Update Policies.json

### DIFF
--- a/jsons/Policies.json
+++ b/jsons/Policies.json
@@ -249,9 +249,8 @@
             {
                 "name": "Theocracy",
                 "uniques": [
-                    "[+10]% [Gold] from every [Temple]"
-                    "[+1 Culture] from every [Shrine]",
-                    "[+1 Gold] from every [Temple]", 
+                    "[+15]% [Gold] from every [Temple]",
+                    "[+1 Gold] from all [Faith] buildings", 
                 ],
                 "requires": ["Organized Religion"],
                 "row": 2,
@@ -269,7 +268,9 @@
             },
             {
                 "name": "Free Religion",
-                "uniques": ["[-15]% Culture cost of adopting new Policies"],
+                "uniques": ["[-15]% Culture cost of adopting new Policies",
+                "[+1 Culture] from every [Trading post]",
+],
                 "requires": ["Mandate Of Heaven", "Reformation"],
                 "row": 3,
                 "column": 4
@@ -345,7 +346,7 @@
                 "name": "Patronage Complete",
                 "uniques": [
                     "Influence of all other civilizations with all city-states degrades [33]% faster",
-                    "Allied City-States provide [Gold] equal to [25]% of what they produce for themselves",
+                    "Allied City-States provide [Gold] equal to [30]% of what they produce for themselves",
                     "Triggers the following global alert: [Our influence with City-States has started dropping faster!]"
                 ]
             }


### PR DESCRIPTION
•Pequeño buff a Patronage, testeandolo me di cuenta que no vale la pena, el 25% de oro no ayuda mucho ya que se necesita oro para mantenerlos. (Sí no le parece dígame y lo quito del PR).

 •+1 de cultura por Trading Post, es el equivalente al de la otra rama, lo puse al final para que no se obtenga fácil, de todos modos no es tan útil como el +1 de ciencia. 

•Reformar la política de Theocracy:
- Se cambia el 10% de oro por 15%, para tratar de igualar el 15% de ciencia dado al inicio de la otra rama. Le hubiera puesto el condicional de solo cuando el imperio está feliz pero no supe cómo, si me dice lo hago.
- Se cambia el +1 de cultura por cada santuario y el +1 de oro por cada templo a +1 de oro por cada edificio de Fé, está sería la versión equivalente a la de racionalismo, la que da +1 de oro por cada edificio de ciencia, sigue siendo peor ya que hay 5 edificios de ciencia y 2 de fé, pero con el 15% se justifica.